### PR TITLE
Add support for running in a Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Start from minimal Ubuntu image that already includes ffmpeg.
+# Ubuntu's ffmpeg package pulls in over 400MB of dependencies.
+FROM jrottenberg/ffmpeg:3.4-ubuntu
+
+RUN apt-get update && \
+  apt-get install -qyy \
+    -o APT::Install-Recommends=false -o APT::Install-Suggests=false \
+    python3 python3-distutils curl ca-certificates
+
+RUN curl -q https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
+  python3 get-pip.py --quiet --no-cache-dir
+
+RUN apt-get purge -y curl && apt-get autoremove -y && apt-get clean
+
+COPY requirements.txt .
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+WORKDIR /
+RUN rm -rf /tmp/workdir
+
+COPY Melt /Melt
+ENTRYPOINT ["/Melt/run"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: docker
+docker:
+	docker build -t audio-analysis .
+
+.PHONY: docker-no-cache
+docker-no-cache:
+	docker build --no-cache -t audio-analysis .
+
+.PHONY: docker-release
+docker-release: docker
+	docker tag audio-analysis cacophonyproject/audio-analysis:latest
+	docker push cacophonyproject/audio-analysis:latest

--- a/Melt/run
+++ b/Melt/run
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cd `dirname $0`
+exec python3 chain.py -examine "$1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+h5py~=2.10.0
+Keras-Applications~=1.0.8
+Keras-Preprocessing~=1.1.0
+numpy~=1.17.3
+scipy~=1.3.1
+tensorflow==2.0.0
+Wave~=0.0.2
+
+

--- a/run
+++ b/run
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+source="$1"
+if [[ ! -f $source ]]; then
+   echo "Please specify an audio file"
+   exit 1
+fi
+
+dir=$(readlink -f "$(dirname "$source")")
+filename=$(basename "$source")
+
+docker run -it -v "$dir":/io cacophonyproject/audio-analysis /io/"$filename"


### PR DESCRIPTION
These are the changes for building and running audio-analysis inside a Docker container.

Still to do: 
- document how this stuff works
- versioning
- releases straight out of TravisCI

I have already published the initial image to Docker Hub at [cacophonyproject/audio-analysis](https://hub.docker.com/repository/docker/cacophonyproject/audio-analysis).

This is enough to get us up and running though.